### PR TITLE
support arbitrary request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ Each chunk must contain one or more request lines (lines beginning with `>>`),
 in accordance with the following grammar:
 
 ```ebnf
-request lines       = main request line , { form data line } ;
+request lines       = main request line , { request body } ;
 main request line   = request prefix , method name , pathname , "\n" ;
 method name         = "GET" | "POST" | "PUT" | "HEAD" | "PATCH" | "MERGE" | "DELETE" ;
 pathname            = { any character } ;
-form data line      = request prefix , param name , "=" , param value , "\n" ;
-param name          = { any character } ;
-param value         = { any character } ;
+request body        = inline body ;
+inline body         = inline body line , { inline body line } ;
+inline body line    = request prefix , "=" , { any character } , "\n" ;
 request prefix      = ">>" , { " " } ;
 any character       = ? any character except "\n" ? ;
 ```

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "./lib/nockingbird",
   "dependencies": {
-    "ramda": "0.5.x"
+    "ramda": "0.7.x"
   },
   "devDependencies": {
     "coffee-script": "1.8.x",

--- a/test/nb/request-bodies.nb
+++ b/test/nb/request-bodies.nb
@@ -1,0 +1,20 @@
+>> POST /
+>> =username=alice&password=%23%24%25&remember_me=on
+<< 200
+<< =
+
+
+>> POST /
+>> ={"username":"alice","password":"#$%","remember_me":true}
+<< 200
+<< =
+
+
+>> POST /
+>> ={
+>> =  "username": "alice",
+>> =  "password": "#$%",
+>> =  "remember_me": true
+>> =}
+<< 200
+<< =

--- a/test/nockingbird.coffee
+++ b/test/nockingbird.coffee
@@ -95,3 +95,19 @@ describe 'nockingbird.load', ->
     scope = new Scope
     nockingbird.load scope, "#{__dirname}/nb/hello-world.nb"
     assert.strictEqual scope.__log__[1][1], 200
+
+  it 'parses request-bodies.nb', ->
+    scope = new Scope
+    nockingbird.load scope, "#{__dirname}/nb/request-bodies.nb"
+    assert.deepEqual scope.__log__, [
+      ['post', '/', 'username=alice&password=%23%24%25&remember_me=on']
+      ['reply', 200, '', {}]
+      ['post', '/', '{"username":"alice","password":"#$%","remember_me":true}']
+      ['reply', 200, '', {}]
+      ['post', '/', '''{
+                         "username": "alice",
+                         "password": "#$%",
+                         "remember_me": true
+                       }''']
+      ['reply', 200, '', {}]
+    ]


### PR DESCRIPTION
Currently we only support percent-encoded form bodies, but one may wish to mock a JSON request, for example. This pull request allows arbitrary request bodies. Like response bodies, these may span multiple lines.
